### PR TITLE
Update to go 1.19 and appengine v2

### DIFF
--- a/app/account.go
+++ b/app/account.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"time"
 
-	"google.golang.org/appengine/datastore"
+	"google.golang.org/appengine/v2/datastore"
 
 	"github.com/google/go-github/github"
 	"golang.org/x/oauth2"

--- a/app/admin.go
+++ b/app/admin.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"strconv"
 
-	"google.golang.org/appengine"
+	"google.golang.org/appengine/v2"
 
 	"github.com/google/go-github/github"
 )

--- a/app/app.go
+++ b/app/app.go
@@ -11,9 +11,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"google.golang.org/appengine"
-	"google.golang.org/appengine/log"
-	"google.golang.org/appengine/mail"
+	"google.golang.org/appengine/v2"
+	"google.golang.org/appengine/v2/log"
+	"google.golang.org/appengine/v2/mail"
 
 	"github.com/google/go-github/github"
 	"github.com/gorilla/sessions"

--- a/app/app.yaml
+++ b/app/app.yaml
@@ -1,20 +1,20 @@
-runtime: go111
-
+runtime: go119
+app_engine_apis: true
 handlers:
-- url: /static
-  static_dir: static
-- url: /favicon.ico
-  static_files: static/favicon.ico
-  upload: static/favicon.ico
-- url: /robots.txt
-  static_files: static/robots.txt
-  upload: static/robots.txt
-- url: /digest/cron
-  script: auto
-  login: admin
-- url: /admin/.*
-  script: auto
-  login: admin
-- url: /.*
-  script: auto
-  secure: always
+  - url: /static
+    static_dir: static
+  - url: /favicon.ico
+    static_files: static/favicon.ico
+    upload: static/favicon.ico
+  - url: /robots.txt
+    static_files: static/robots.txt
+    upload: static/robots.txt
+  - url: /digest/cron
+    script: auto
+    login: admin
+  - url: /admin/.*
+    script: auto
+    login: admin
+  - url: /.*
+    script: auto
+    secure: always

--- a/app/caching_transport.go
+++ b/app/caching_transport.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"time"
 
-	"google.golang.org/appengine/log"
-	"google.golang.org/appengine/memcache"
+	"google.golang.org/appengine/v2/memcache"
+	"google.golang.org/appengine/v2/log"
 )
 
 // Simple http.RoundTripper implementation which wraps an existing transport and

--- a/app/digest.go
+++ b/app/digest.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"google.golang.org/appengine/log"
+	"google.golang.org/appengine/v2/log"
 
 	"github.com/google/go-github/github"
 )

--- a/app/go.mod
+++ b/app/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/gorilla/mux v1.2.0
 	github.com/gorilla/sessions v1.1.1
 	golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a
-	google.golang.org/appengine v1.6.7
+	google.golang.org/appengine/v2 v2.0.2
 )
 
 require (
@@ -15,6 +15,7 @@ require (
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/gorilla/context v1.1.1 // indirect
 	github.com/gorilla/securecookie v1.1.1 // indirect
-	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
+	golang.org/x/net v0.0.0-20220708220712-1185a9018129 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.25.0 // indirect
 )

--- a/app/go.sum
+++ b/app/go.sum
@@ -190,8 +190,9 @@ golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
-golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd h1:O7DYs+zxREGLKzKoMQrtrEacpb0ZVXA5rIwylE2Xchk=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
+golang.org/x/net v0.0.0-20220708220712-1185a9018129 h1:vucSRfWwTsoXro7P+3Cjlr6flUMtzCwzlvkxEQtHHB0=
+golang.org/x/net v0.0.0-20220708220712-1185a9018129/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -234,6 +235,7 @@ golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -313,6 +315,8 @@ google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCID
 google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/appengine v1.6.7 h1:FZR1q0exgwxzPzp/aF+VccGrSfxfPpkBqjIIEq3ru6c=
 google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
+google.golang.org/appengine/v2 v2.0.2 h1:MSqyWy2shDLwG7chbwBJ5uMyw6SNqJzhJHNDwYB0Akk=
+google.golang.org/appengine/v2 v2.0.2/go.mod h1:PkgRUWz4o1XOvbqtWTkBtCitEJ5Tp4HoVEdMMYQR/8E=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190418145605-e7d98fc518a7/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=

--- a/app/repos.go
+++ b/app/repos.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"time"
 
-	"google.golang.org/appengine"
-	"google.golang.org/appengine/datastore"
-	"google.golang.org/appengine/delay"
-	"google.golang.org/appengine/log"
-	"google.golang.org/appengine/taskqueue"
+	"google.golang.org/appengine/v2"
+	"google.golang.org/appengine/v2/datastore"
+	"google.golang.org/appengine/v2/delay"
+	"google.golang.org/appengine/v2/log"
+	"google.golang.org/appengine/v2/taskqueue"
 
 	"github.com/google/go-github/github"
 )

--- a/app/retrogit.go
+++ b/app/retrogit.go
@@ -14,12 +14,12 @@ import (
 	"sync"
 	"time"
 
-	"google.golang.org/appengine"
-	"google.golang.org/appengine/datastore"
-	"google.golang.org/appengine/delay"
-	"google.golang.org/appengine/log"
-	"google.golang.org/appengine/mail"
-	"google.golang.org/appengine/urlfetch"
+	"google.golang.org/appengine/v2"
+	"google.golang.org/appengine/v2/datastore"
+	"google.golang.org/appengine/v2/delay"
+	"google.golang.org/appengine/v2/log"
+	"google.golang.org/appengine/v2/mail"
+	"google.golang.org/appengine/v2/urlfetch"
 
 	"github.com/google/go-github/github"
 	"github.com/gorilla/mux"

--- a/app/session.go
+++ b/app/session.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"log"
 
-	"google.golang.org/appengine"
+	"google.golang.org/appengine/v2"
 
 	"github.com/gorilla/sessions"
 )


### PR DESCRIPTION
In order to run on app engine's go 1.12+ runtime I had to bump these versions.